### PR TITLE
Adds type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function classies(def: Record<string, boolean | undefined | null | string | number>, separator?: string): string;
+
+export = classies;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "bugs": {
     "url": "https://github.com/StephanHoyer/classies/issues"
   },
+  "types": "index.d.ts",
   "homepage": "https://github.com/StephanHoyer/classies#readme",
   "devDependencies": {
     "ospec": "4.1.1"


### PR DESCRIPTION
As you can see, the `null, string, and number` types are here too. Thats because it can be used too.
Example:
```tsx
{/*  `userInput` may be an empty string, so `alert` class will be added. */}
<div className={classies({ 'alert': userInput })} />
```
However, I can remove it if it is unnecessary.